### PR TITLE
Fixes #1966

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -277,6 +277,7 @@ def parse_arguments():
                         '"output" in the current path.')
 
     parser.add_argument('-s', '--settings', dest='settings',
+                        default=DEFAULT_CONFIG_NAME,
                         help='The settings of the application, this is '
                         'automatically set to {0} if a file exists with this '
                         'name.'.format(DEFAULT_CONFIG_NAME))


### PR DESCRIPTION
Add a default to the settings filename in the argparse configuration. This will enable the triggering of the reload function when the configuration file is not explicitly defined.
